### PR TITLE
Remove mention of LLE libraries that are now completely replaced by their HLE versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,12 @@ The following firmware modules are supported and must be placed under `user/sys_
 Tested firmware modules are from **11.00**.
 
 - **libSceNgs2.sprx**
-- **libSceFiber.sprx**
 - **libSceUlt.sprx**
 - **libSceJson.sprx**
 - **libSceJson2.sprx**
 - **libSceLibcInternal.sprx**
 - **libSceDiscMap.sprx**
 - **libSceRtc.sprx**
-- **libSceJpegEnc.sprx**
 - **libSceCesCs.sprx**
 - **libSceFont.sprx**
 - **libSceFontFt.sprx**


### PR DESCRIPTION
An extension of https://github.com/shadps4-emu/shadPS4/pull/2012